### PR TITLE
Improve trip filtering logic

### DIFF
--- a/src/lib/utils/filterTrips.ts
+++ b/src/lib/utils/filterTrips.ts
@@ -1,0 +1,26 @@
+import { Trip } from "../types/trips";
+import { FILTER_KEY_NAME } from "../context/TripsContext";
+import { Style } from "../types/trips";
+
+export type Filters = Partial<Record<FILTER_KEY_NAME, string>>;
+
+export const filterTrips = (
+  tripSet: Trip[] = [],
+  filters: Filters = {}
+): Trip[] => {
+  const activeFilters = Object.entries(filters).filter(([, value]) => {
+    if (!value) return false;
+    if (value.toLowerCase() === Style.All.toLowerCase()) return false;
+    return true;
+  });
+
+  if (activeFilters.length === 0) {
+    return tripSet;
+  }
+
+  return tripSet.filter((trip) =>
+    activeFilters.every(
+      ([key, value]) => trip[key as keyof Trip] === value
+    )
+  );
+};

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import SortBtn from "../../components/SortBtn";
 import TripFilterList from "../../components/TripFilterList";
 import TripList from "../../components/TripList";
@@ -9,7 +9,8 @@ import {
   useTripsContext,
 } from "../../lib/context/TripsContext";
 import useTrips from "../../lib/hooks/useTrips";
-import { Trip, Trips } from "../../lib/types/trips";
+import { Trips } from "../../lib/types/trips";
+import { filterTrips } from "../../lib/utils/filterTrips";
 import styles from "./styles.module.scss";
 
 const Home = () => {
@@ -18,54 +19,41 @@ const Home = () => {
   const [sortByCheckIn, setSortByCheckIn] = useState<boolean>(true);
   const [tripSet, setTripSet] = useState<Trips["tripSet"]>();
 
-  const sortByCheckInDate = useCallback(
-    (isSort: boolean) => {
-      const dataSrc = filteredTrips || trips?.tripSet;
-
-      const sortData = dataSrc?.sort((a, b) => {
-        if (!isSort) {
-          return (
-            new Date(b.checkInDate).valueOf() -
-            new Date(a.checkInDate).valueOf()
-          );
-        }
-
-        return (
-          new Date(a.checkInDate).valueOf() - new Date(b.checkInDate).valueOf()
-        );
-      });
-      setTripSet(sortData);
-    },
-    [filteredTrips, trips?.tripSet]
-  );
-
   useEffect(() => {
-    sortByCheckInDate(sortByCheckIn);
-  }, [sortByCheckIn, sortByCheckInDate]);
+    const dataSrc = filteredTrips || trips?.tripSet;
+    const sortedData = [...(dataSrc || [])].sort((a, b) => {
+      if (!sortByCheckIn) {
+        return (
+          new Date(b.checkInDate).valueOf() - new Date(a.checkInDate).valueOf()
+        );
+      }
+
+      return (
+        new Date(a.checkInDate).valueOf() - new Date(b.checkInDate).valueOf()
+      );
+    });
+    setTripSet(sortedData);
+  }, [sortByCheckIn, filteredTrips, trips?.tripSet]);
 
   const handleSortByCheckIn = () => {
-    sortByCheckInDate(!sortByCheckIn);
     setSortByCheckIn(!sortByCheckIn);
   };
 
-  const filterTrips = (filterKeyName: FILTER_KEY_NAME, filterValue: string) => {
-    let _filters: { [key: string]: string } = filters ? filters : {};
-    _filters = {
-      ..._filters,
+  const getFilteredTrips = (
+    filterKeyName: FILTER_KEY_NAME,
+    filterValue: string
+  ) => {
+    const nextFilters = {
+      ...(filters || {}),
       [filterKeyName]: filterValue,
     };
 
-    return trips?.tripSet.filter((tripSetItem: any) => {
-      if (filterValue.toLowerCase() === "all vacations") return true;
-      return Object.entries(_filters).every(
-        ([key, val]) => tripSetItem[key] === val
-      );
-    }) as Trip[];
+    return filterTrips(trips?.tripSet || [], nextFilters);
   };
 
   const handleStyleFilterClick = (filterValue: string) => {
     dispatch(addFilter({ [FILTER_KEY_NAME.UnitStyleName]: filterValue }));
-    const filterTripsData = filterTrips(
+    const filterTripsData = getFilteredTrips(
       FILTER_KEY_NAME.UnitStyleName,
       filterValue
     );
@@ -74,7 +62,7 @@ const Home = () => {
 
   const handleCategoryFilterClick = (filterValue: string) => {
     dispatch(addFilter({ [FILTER_KEY_NAME.ParentCategoryName]: filterValue }));
-    const filterTripsData = filterTrips(
+    const filterTripsData = getFilteredTrips(
       FILTER_KEY_NAME.ParentCategoryName,
       filterValue
     );


### PR DESCRIPTION
## Summary
- centralize trip filtering in a new utility function
- simplify sorting logic and avoid mutating the trips array
- update Home page to use the new `filterTrips` helper

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: no tests specified)*
- `npm run build` *(fails: vite not found)*